### PR TITLE
Add `--fen` support across `play`, `pvp`, `watch`, and `calculate-best-move` (new)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
+    calculate-best-move        Use the chess engine to determine the best move from a given position, provided in
+                               FEN notation with `--fen` (required). You can optionally specify the depth of the
+                               search with the `--depth` arg (default: 4).
     count-positions            Count the number of possible positions for a given `--depth` (default: 4), and
                                reports the time it took to do so. By default, this searches all possible positions.
                                The routine can be run with alpha-beta pruning by selecting `--strategy alpha-beta`.
@@ -37,10 +40,39 @@ SUBCOMMANDS:
     help                       Prints this message or the help of the given subcommand(s)
     play                       Play a game against the computer, which will search for the best move using alpha-
                                beta pruning at the given `--depth` (default: 4). Your starting color will be
-                               chosen at random unless you specify with `--color`.
-    pvp                        Play a game against another human on this local machine.
-    watch                      Watch the computer play against itself at the given `--depth` (default: 4).
+                               chosen at random unless you specify with `--color`. The initial position can be
+                               specified using FEN notation with `--fen` (default: starting position).
+    pvp                        Play a game against another human on this local machine. The initial position can be
+                               specified using FEN notation with `--fen` (default: starting position).
+    watch                      Watch the computer play against itself at the given `--depth` (default: 4). The
+                               initial position can be specified using FEN notation with `--fen` (default: starting
+                               position).
+
 ```
+
+### Starting from a custom position
+
+You can start a game from any valid chess position by specifying it in FEN (Forsyth–Edwards Notation) format. For example:
+
+```console
+$ chess play --fen "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2"
+```
+
+This starts a game from the Sicilian Defense position after 1.e4 c5 2.Nf3. The default starting position is used if no FEN is specified.
+
+The `--fen` parameter is available for the `play`, `pvp`, and `watch` commands. Each command will validate the FEN string and ensure it represents a legal chess position before starting the game.
+
+
+### Calculating the best move from a given position
+
+There is also the option to calculate the best move from a given position. For example:
+
+```console
+$ chess calculate-best-move --fen "1Q6/8/8/8/8/k1K5/8/8 w - - 0 1"
+Qb3#
+```
+
+This evaluates the position using the engine at a default `--depth` of `4`, and writes the result to `stdout` in algebraic notation.
 
 ## Performance
 

--- a/benches/count_positions_benchmark.rs
+++ b/benches/count_positions_benchmark.rs
@@ -7,7 +7,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("count all possible positions to depth 4", |b| {
         b.iter(|| {
             let mut move_generator = MoveGenerator::new();
-            move_generator.count_positions(4, &mut Board::starting_position(), Color::White)
+            move_generator.count_positions(4, &mut Board::default(), Color::White)
         })
     });
 }

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -13,8 +13,12 @@ use common::bitboard::bitboard::Bitboard;
 use error::BoardError;
 use piece::Piece;
 use piece_set::PieceSet;
+use std::str::FromStr;
 
-use crate::chess_position;
+use crate::{
+    chess_position,
+    input_handler::fen::{parse_fen, FenParseError},
+};
 
 use self::{
     castle_rights_bitmask::CastleRightsBitmask, move_info::MoveInfo, position_info::PositionInfo,
@@ -229,6 +233,14 @@ impl Board {
 
     pub fn current_position_hash(&self) -> u64 {
         self.position_info.current_position_hash()
+    }
+}
+
+impl FromStr for Board {
+    type Err = FenParseError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        parse_fen(input)
     }
 }
 

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -34,29 +34,6 @@ pub struct Board {
 
 impl Default for Board {
     fn default() -> Self {
-        Self {
-            white: PieceSet::new(),
-            black: PieceSet::new(),
-            turn: Color::White,
-            move_info: MoveInfo::new(),
-            position_info: PositionInfo::new(),
-        }
-    }
-}
-
-impl Board {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn pieces(&self, color: Color) -> &PieceSet {
-        match color {
-            Color::White => &self.white,
-            Color::Black => &self.black,
-        }
-    }
-
-    pub fn starting_position() -> Self {
         chess_position! {
             rnbqkbnr
             pppppppp
@@ -66,6 +43,25 @@ impl Board {
             ........
             PPPPPPPP
             RNBQKBNR
+        }
+    }
+}
+
+impl Board {
+    pub fn new() -> Self {
+        Self {
+            white: PieceSet::new(),
+            black: PieceSet::new(),
+            turn: Color::White,
+            move_info: MoveInfo::new(),
+            position_info: PositionInfo::new(),
+        }
+    }
+
+    pub fn pieces(&self, color: Color) -> &PieceSet {
+        match color {
+            Color::White => &self.white,
+            Color::Black => &self.black,
         }
     }
 
@@ -249,8 +245,8 @@ mod tests {
 
     #[test]
     fn test_zobrist_hashing_is_equal_for_transpositions() {
-        let mut board1 = Board::starting_position();
-        let mut board2 = Board::starting_position();
+        let mut board1 = Board::default();
+        let mut board2 = Board::default();
         let initial_hash_1 = board1.current_position_hash();
         let initial_hash_2 = board2.current_position_hash();
         assert_eq!(initial_hash_1, initial_hash_2);

--- a/src/chess_move/algebraic_notation.rs
+++ b/src/chess_move/algebraic_notation.rs
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_algebraic_notation_for_basic_moves() {
-        let mut board = Board::starting_position();
+        let mut board = Board::default();
         board.set_turn(Color::White);
 
         assert_move_has_algebraic_notation!(board, Color::White, std_move!(E2, E4), "e4");

--- a/src/chess_move/standard.rs
+++ b/src/chess_move/standard.rs
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn test_apply_chess_move() {
-        let mut board = Board::starting_position();
+        let mut board = Board::default();
         println!("Testing board:\n{}", board);
 
         // using a queens gambit accepted opening to test basic chess move application
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_undo_pawn_move() {
-        let mut board = Board::starting_position();
+        let mut board = Board::default();
         let original_board = format!("{}", board);
         println!("Testing board:\n{}", board);
 
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_undo_knight_move() {
-        let mut board = Board::starting_position();
+        let mut board = Board::default();
         let original_board = format!("{}", board);
         println!("Testing board:\n{}", board);
 

--- a/src/evaluate/mod.rs
+++ b/src/evaluate/mod.rs
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_starting_player_material_score() {
-        let board = Board::starting_position();
+        let board = Board::default();
         println!("Testing board:\n{}", board);
 
         let white_score = player_material_score(&board, Color::White);
@@ -288,8 +288,8 @@ mod tests {
     }
 
     #[test]
-    fn test_starting_position_is_not_endgame() {
-        let board = Board::starting_position();
+    fn test_default_is_not_endgame() {
+        let board = Board::default();
         assert!(!is_endgame(&board));
     }
 

--- a/src/game/engine.rs
+++ b/src/game/engine.rs
@@ -39,7 +39,7 @@ pub struct GameState {
 impl Default for GameState {
     fn default() -> Self {
         Self {
-            board: Board::starting_position(),
+            board: Board::default(),
             move_history: Vec::new(),
             last_score: None,
         }

--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -1,0 +1,348 @@
+use crate::alpha_beta_searcher::{alpha_beta_search, SearchContext, SearchError};
+use crate::board::color::Color;
+use crate::board::error::BoardError;
+use crate::board::Board;
+use crate::book::{Book, BookMove};
+use crate::chess_move::algebraic_notation::enumerate_candidate_moves_with_algebraic_notation;
+use crate::chess_move::chess_move::ChessMove;
+use crate::evaluate::{self, GameEnding};
+use crate::move_generator::MoveGenerator;
+use common::bitboard::bitboard::Bitboard;
+use common::bitboard::square;
+use rand::{self, Rng};
+use thiserror::Error;
+
+/// Represents the state and control of a chess game.
+pub struct Game {
+    board: Board,
+    move_history: Vec<ChessMove>,
+    book: Book,
+    move_generator: MoveGenerator,
+    search_context: SearchContext,
+}
+
+#[derive(Error, Debug)]
+pub enum GameError {
+    #[error("{move_str:?} is not a valid move")]
+    InvalidMove { move_str: String },
+    #[error("board error: {error:?}")]
+    BoardError { error: BoardError },
+    #[error("search error: {error:?}")]
+    SearchError { error: SearchError },
+}
+
+impl Game {
+    pub fn new(search_depth: u8) -> Self {
+        Self::from_board(Board::starting_position(), search_depth)
+    }
+
+    pub fn from_board(board: Board, search_depth: u8) -> Self {
+        Self {
+            board,
+            move_history: Vec::new(),
+            book: Book::default(),
+            move_generator: MoveGenerator::new(),
+            search_context: SearchContext::new(search_depth),
+        }
+    }
+
+    pub fn board(&self) -> &Board {
+        &self.board
+    }
+
+    pub fn board_mut(&mut self) -> &mut Board {
+        &mut self.board
+    }
+
+    pub fn enumerated_candidate_moves(&mut self) -> Vec<(ChessMove, String)> {
+        let board = &mut self.board;
+        let current_turn = board.turn();
+        let move_generator = &mut self.move_generator;
+        enumerate_candidate_moves_with_algebraic_notation(board, current_turn, move_generator)
+    }
+
+    pub fn check_game_over_for_current_turn(&mut self) -> Option<GameEnding> {
+        let turn = self.board.turn();
+        evaluate::game_ending(&mut self.board, &mut self.move_generator, turn)
+    }
+
+    pub fn save_move(&mut self, chess_move: ChessMove) {
+        self.move_history.push(chess_move);
+    }
+
+    pub fn most_recent_move(&self) -> Option<ChessMove> {
+        self.move_history.iter().last().cloned()
+    }
+
+    pub fn apply_chess_move_by_from_to_coordinates(
+        &mut self,
+        from_square: Bitboard,
+        to_square: Bitboard,
+    ) -> Result<ChessMove, GameError> {
+        let turn = self.board.turn();
+        let candidates = self.move_generator.generate_moves(&mut self.board, turn);
+        let move_str = format!(
+            "{}{}",
+            square::to_algebraic(from_square),
+            square::to_algebraic(to_square)
+        );
+        let chess_move = candidates
+            .iter()
+            .find(|m| m.from_square() == from_square && m.to_square() == to_square)
+            .ok_or(GameError::InvalidMove { move_str })?;
+        self.apply_chess_move(chess_move.clone())?;
+        Ok(chess_move.clone())
+    }
+
+    pub fn apply_chess_move(&mut self, chess_move: ChessMove) -> Result<(), GameError> {
+        match chess_move.apply(&mut self.board) {
+            Ok(_capture) => {
+                self.save_move(chess_move.clone());
+                Ok(())
+            }
+            Err(error) => Err(GameError::BoardError { error }),
+        }
+    }
+
+    pub fn apply_chess_move_from_raw_algebraic_notation(
+        &mut self,
+        algebraic: String,
+    ) -> Result<ChessMove, GameError> {
+        let board = &mut self.board;
+        let current_turn = board.turn();
+        let move_generator = &mut self.move_generator;
+        let enumerated_candidate_moves =
+            enumerate_candidate_moves_with_algebraic_notation(board, current_turn, move_generator);
+        let chess_move = enumerated_candidate_moves
+            .iter()
+            .find(|m| m.1 == algebraic)
+            .ok_or(GameError::InvalidMove {
+                move_str: algebraic,
+            })?
+            .0
+            .clone();
+        self.apply_chess_move(chess_move.clone())?;
+        Ok(chess_move)
+    }
+
+    pub fn select_alpha_beta_best_move(&mut self) -> Result<ChessMove, GameError> {
+        alpha_beta_search(
+            &mut self.search_context,
+            &mut self.board,
+            &mut self.move_generator,
+        )
+        .map_err(|err| GameError::SearchError { error: err })
+    }
+
+    pub fn make_alpha_beta_best_move(&mut self) -> Result<ChessMove, GameError> {
+        let best_move = self.select_alpha_beta_best_move()?;
+        best_move
+            .apply(&mut self.board)
+            .map_err(|error| GameError::BoardError { error })?;
+        self.save_move(best_move.clone());
+        Ok(best_move)
+    }
+
+    pub fn select_waterfall_book_then_alpha_beta_best_move(
+        &mut self,
+    ) -> Result<ChessMove, GameError> {
+        let current_turn = self.board.turn();
+        let line = self.get_book_line();
+        let candidate_book_moves = self.book.get_next_moves(line);
+
+        if candidate_book_moves.is_empty() {
+            return self.select_alpha_beta_best_move();
+        }
+
+        let rng = rand::thread_rng().gen_range(0..candidate_book_moves.len());
+        let (book_move, _line_name) = &candidate_book_moves[rng];
+        let from_square = book_move.from_square();
+        let to_square = book_move.to_square();
+        let move_str = format!(
+            "{}{}",
+            square::to_algebraic(from_square),
+            square::to_algebraic(to_square)
+        );
+
+        let candidates = self
+            .move_generator
+            .generate_moves_and_lazily_update_chess_move_effects(&mut self.board, current_turn);
+
+        let maybe_chess_move = candidates
+            .iter()
+            .find(|m| m.from_square() == from_square && m.to_square() == to_square);
+
+        match maybe_chess_move {
+            Some(result) => Ok(result.clone()),
+            None => return Err(GameError::InvalidMove { move_str }),
+        }
+    }
+
+    pub fn make_waterfall_book_then_alpha_beta_move(&mut self) -> Result<ChessMove, GameError> {
+        let chess_move = self.select_waterfall_book_then_alpha_beta_best_move()?;
+        match chess_move.apply(&mut self.board) {
+            Ok(_capture) => {
+                self.save_move(chess_move.clone());
+                Ok(chess_move.clone())
+            }
+            Err(error) => Err(GameError::BoardError { error }),
+        }
+    }
+
+    pub fn score(&mut self, current_turn: Color) -> i16 {
+        evaluate::score(&mut self.board, &mut self.move_generator, current_turn, 0)
+    }
+
+    pub fn fullmove_clock(&self) -> u8 {
+        self.board.fullmove_clock()
+    }
+
+    pub fn searched_position_count(&self) -> usize {
+        self.search_context.searched_position_count()
+    }
+
+    pub fn alpha_beta_cache_hit_count(&self) -> usize {
+        self.search_context.cache_hit_count()
+    }
+
+    pub fn alpha_beta_termination_count(&self) -> usize {
+        self.search_context.termination_count()
+    }
+
+    pub fn search_depth(&self) -> u8 {
+        self.search_context.search_depth()
+    }
+
+    pub fn alpha_beta_score(&self) -> Option<i16> {
+        self.search_context.last_score()
+    }
+
+    pub fn move_generator_cache_hit_count(&self) -> usize {
+        self.move_generator.cache_hit_count()
+    }
+
+    pub fn move_genereator_cache_entry_count(&self) -> usize {
+        self.move_generator.cache_entry_count()
+    }
+
+    pub fn reset_move_generator_cache_hit_count(&mut self) {
+        self.move_generator.reset_cache_hit_count();
+    }
+
+    pub fn last_move(&self) -> Option<ChessMove> {
+        self.move_history.last().cloned()
+    }
+
+    pub fn get_book_line_name(&self) -> Option<String> {
+        let line = self.get_book_line();
+        self.book.get_line(line)
+    }
+
+    fn get_book_line(&self) -> Vec<BookMove> {
+        self.move_history
+            .iter()
+            .map(|m| BookMove::new(m.from_square(), m.to_square()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::board::castle_rights_bitmask::ALL_CASTLE_RIGHTS;
+    use crate::board::piece::Piece;
+    use crate::chess_move::chess_move::ChessMove;
+    use crate::chess_move::chess_move_effect::ChessMoveEffect;
+    use crate::chess_move::standard::StandardChessMove;
+    use crate::{chess_position, std_move};
+    use common::bitboard::square;
+
+    #[test]
+    fn test_score() {
+        let mut game = Game::new(0);
+        game.apply_chess_move_by_from_to_coordinates(square::E2, square::E4)
+            .unwrap();
+        game.board.toggle_turn();
+        assert!(game.check_game_over_for_current_turn().is_none());
+    }
+
+    #[test]
+    fn test_checkmate() {
+        let mut game = Game::new(0);
+        game.apply_chess_move_by_from_to_coordinates(square::F2, square::F3)
+            .unwrap();
+        game.board.toggle_turn();
+        game.apply_chess_move_by_from_to_coordinates(square::E7, square::E6)
+            .unwrap();
+        game.board.toggle_turn();
+        game.apply_chess_move_by_from_to_coordinates(square::G2, square::G4)
+            .unwrap();
+        game.board.toggle_turn();
+        game.apply_chess_move_by_from_to_coordinates(square::D8, square::H4)
+            .unwrap();
+        game.board.toggle_turn();
+        println!("Testing board:\n{}", game.board);
+        matches!(
+            game.check_game_over_for_current_turn(),
+            Some(GameEnding::Checkmate)
+        );
+    }
+
+    #[test]
+    fn test_draw_from_repetition() {
+        let mut board = chess_position! {
+            .......k
+            .......r
+            ........
+            ........
+            ........
+            ........
+            K.......
+            R.......
+        };
+        board.set_turn(Color::White);
+        board.lose_castle_rights(ALL_CASTLE_RIGHTS);
+
+        // make sure starting position has been counted
+        board.count_current_position();
+
+        let mut game = Game::from_board(board, 0);
+        println!("Testing board:\n{}", game.board);
+
+        let first_moves = [
+            std_move!(square::A2, square::A3),
+            std_move!(square::H8, square::G8),
+            std_move!(square::A3, square::A2),
+            std_move!(square::G8, square::H8),
+        ];
+
+        for m in first_moves.iter() {
+            m.apply(&mut game.board).unwrap();
+            game.board.toggle_turn();
+        }
+
+        // back in starting position for second time
+        matches!(
+            game.check_game_over_for_current_turn(),
+            Some(GameEnding::Draw)
+        );
+
+        let second_moves = [
+            std_move!(square::A2, square::A3),
+            std_move!(square::H8, square::G8),
+            std_move!(square::A3, square::A2),
+            std_move!(square::G8, square::H8),
+        ];
+
+        for m in second_moves.iter() {
+            m.apply(&mut game.board).unwrap();
+            game.board.toggle_turn();
+        }
+
+        // back in starting position for third time, should be draw
+        matches!(
+            game.check_game_over_for_current_turn(),
+            Some(GameEnding::Draw)
+        );
+    }
+}

--- a/src/game/loop.rs
+++ b/src/game/loop.rs
@@ -11,14 +11,9 @@ pub struct GameLoop<T: GameMode> {
 }
 
 impl<T: GameMode> GameLoop<T> {
-    pub fn new(mode: T, depth: Option<u8>) -> Self {
-        let engine = match depth {
-            Some(d) => Engine::with_config(EngineConfig { search_depth: d }),
-            None => Engine::new(),
-        };
-
+    pub fn new(mode: T, config: EngineConfig) -> Self {
         Self {
-            engine,
+            engine: Engine::with_config(config),
             ui: GameDisplay::new(),
             mode,
         }

--- a/src/game/mode.rs
+++ b/src/game/mode.rs
@@ -22,8 +22,9 @@ pub struct HumanVsComputer {
 }
 
 pub struct ComputerVsComputer {
-    pub depth: u8,
-    pub delay: Option<Duration>,
+    /// The engine can calculate moves very quickly, so adding a slight delay
+    /// between moves makes the game easier to observe.
+    pub delay_between_moves: Option<Duration>,
 }
 
 pub struct HumanVsHuman;
@@ -101,7 +102,7 @@ impl GameMode for ComputerVsComputer {
     }
 
     fn frame_delay(&self) -> Option<Duration> {
-        self.delay
+        self.delay_between_moves
     }
 }
 

--- a/src/game/position_counter.rs
+++ b/src/game/position_counter.rs
@@ -31,7 +31,7 @@ pub fn run_count_positions(depth: u8, strategy: CountPositionsStrategy) {
     let mut total_duration = Duration::from_secs(0);
 
     for depth in depths {
-        let mut board = Board::starting_position();
+        let mut board = Board::default();
 
         let starting_time = SystemTime::now();
         let count = match strategy {

--- a/src/game/stockfish_elo.rs
+++ b/src/game/stockfish_elo.rs
@@ -82,6 +82,7 @@ pub fn determine_stockfish_elo(depth: u8, starting_elo: u32) {
 fn play_game(stockfish: &mut Stockfish, depth: u8) -> (GameResult, Duration, Duration) {
     let mut engine = Engine::with_config(EngineConfig {
         search_depth: depth,
+        starting_position: Board::default(),
     });
     let mut moves = Vec::new();
     let mut engine_time = Duration::new(0, 0);

--- a/src/input_handler/fen.rs
+++ b/src/input_handler/fen.rs
@@ -1,0 +1,346 @@
+use crate::board::{
+    castle_rights_bitmask::*, color::Color, error::BoardError, piece::Piece, Board,
+};
+use common::bitboard::square::from_rank_file;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum FenParseError {
+    #[error("Wrong number of fields")]
+    WrongNumberOfFields,
+    #[error("Invalid piece character: {invalid_character:?}")]
+    InvalidPieceCharacter { invalid_character: char },
+    #[error("Wrong number of ranks: 8 expected, {rank_count:?} given")]
+    InvalidRankCount { rank_count: usize },
+    #[error("Rank too long: {invalid_rank:?}")]
+    InvalidRankLength { invalid_rank: String },
+    #[error("Error placing piece: {board_error:?}")]
+    ErrorPlacingPiece { board_error: BoardError },
+    #[error("Rank incomplete: {incomplete_rank:?}")]
+    IncompleteRank { incomplete_rank: String },
+    #[error("Invalid color: {invalid_color:?}")]
+    InvalidColor { invalid_color: String },
+    #[error("Invalid castling rights: {invalid_castling:?}")]
+    InvalidCastlingRights { invalid_castling: char },
+    #[error("Invalid en passant {component:?}: {value:?}")]
+    InvalidEnPassant { component: String, value: String },
+    #[error("Invalid halfmove clock: {invalid_clock:?}")]
+    InvalidHalfmoveClock { invalid_clock: String },
+    #[error("Invalid fullmove number: {invalid_number:?}")]
+    InvalidFullmoveNumber { invalid_number: String },
+}
+
+type FenResult<T> = Result<T, FenParseError>;
+
+pub const STARTING_POSITION_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+/// Parses a FEN (Forsyth–Edwards Notation) string into a Board.
+/// FEN string contains 6 fields: piece placement, active color, castling rights,
+/// en passant target square, halfmove clock, and fullmove number.
+pub fn parse_fen(fen: &str) -> FenResult<Board> {
+    let fields = split_fen_fields(fen)?;
+    let mut board = Board::new();
+
+    parse_piece_placement(&mut board, fields.position)?;
+    parse_active_color(&mut board, fields.active_color)?;
+    parse_castle_rights(&mut board, fields.castle_rights)?;
+    parse_en_passant(&mut board, fields.en_passant)?;
+    parse_halfmove_clock(&mut board, fields.halfmove_clock)?;
+    parse_fullmove_number(&mut board, fields.fullmove_number)?;
+
+    Ok(board)
+}
+
+/// Represents the six fields in a FEN string
+struct FenFields<'a> {
+    position: &'a str,
+    active_color: &'a str,
+    castle_rights: &'a str,
+    en_passant: &'a str,
+    halfmove_clock: &'a str,
+    fullmove_number: &'a str,
+}
+
+/// Splits a FEN string into its six component fields
+fn split_fen_fields(fen: &str) -> FenResult<FenFields> {
+    let parts: Vec<&str> = fen.split_whitespace().collect();
+    if parts.len() != 6 {
+        return Err(FenParseError::WrongNumberOfFields);
+    }
+
+    Ok(FenFields {
+        position: parts[0],
+        active_color: parts[1],
+        castle_rights: parts[2],
+        en_passant: parts[3],
+        halfmove_clock: parts[4],
+        fullmove_number: parts[5],
+    })
+}
+
+/// Maps a FEN piece character to its corresponding piece type and color
+fn parse_piece_char(c: char) -> FenResult<(Piece, Color)> {
+    match c {
+        'P' => Ok((Piece::Pawn, Color::White)),
+        'N' => Ok((Piece::Knight, Color::White)),
+        'B' => Ok((Piece::Bishop, Color::White)),
+        'R' => Ok((Piece::Rook, Color::White)),
+        'Q' => Ok((Piece::Queen, Color::White)),
+        'K' => Ok((Piece::King, Color::White)),
+        'p' => Ok((Piece::Pawn, Color::Black)),
+        'n' => Ok((Piece::Knight, Color::Black)),
+        'b' => Ok((Piece::Bishop, Color::Black)),
+        'r' => Ok((Piece::Rook, Color::Black)),
+        'q' => Ok((Piece::Queen, Color::Black)),
+        'k' => Ok((Piece::King, Color::Black)),
+        _ => Err(FenParseError::InvalidPieceCharacter {
+            invalid_character: c,
+        }),
+    }
+}
+
+/// Parses the piece placement section of the FEN string
+fn parse_piece_placement(board: &mut Board, position: &str) -> FenResult<()> {
+    let ranks: Vec<&str> = position.split('/').collect();
+    if ranks.len() != 8 {
+        return Err(FenParseError::InvalidRankCount {
+            rank_count: ranks.len(),
+        });
+    }
+
+    for (rank_idx, rank) in ranks.iter().enumerate() {
+        parse_rank(board, rank, 7 - rank_idx as u8)?;
+    }
+
+    Ok(())
+}
+
+/// Parses a single rank of the piece placement section
+fn parse_rank(board: &mut Board, rank: &str, rank_number: u8) -> FenResult<()> {
+    let mut file = 0u8;
+
+    for c in rank.chars() {
+        if file >= 8 {
+            return Err(FenParseError::InvalidRankLength {
+                invalid_rank: rank.to_string(),
+            });
+        }
+
+        if let Some(empty_squares) = c.to_digit(10) {
+            file += empty_squares as u8;
+        } else {
+            let (piece, color) = parse_piece_char(c)?;
+            board
+                .put(from_rank_file(rank_number, file), piece, color)
+                .map_err(|e| FenParseError::ErrorPlacingPiece { board_error: e })?;
+            file += 1;
+        }
+    }
+
+    if file != 8 {
+        return Err(FenParseError::IncompleteRank {
+            incomplete_rank: rank.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Parses the active color field
+fn parse_active_color(board: &mut Board, active_color: &str) -> FenResult<()> {
+    match active_color {
+        "w" => {
+            board.set_turn(Color::White);
+            Ok(())
+        }
+        "b" => {
+            board.set_turn(Color::Black);
+            Ok(())
+        }
+        _ => Err(FenParseError::InvalidColor {
+            invalid_color: active_color.to_string(),
+        }),
+    }
+}
+
+/// Parses the castling rights field
+fn parse_castle_rights(board: &mut Board, castle_rights: &str) -> FenResult<()> {
+    if castle_rights == "-" {
+        board.lose_castle_rights(ALL_CASTLE_RIGHTS);
+        return Ok(());
+    }
+
+    let mut rights = 0u8;
+    for c in castle_rights.chars() {
+        rights |= match c {
+            'K' => WHITE_KINGSIDE_RIGHTS,
+            'Q' => WHITE_QUEENSIDE_RIGHTS,
+            'k' => BLACK_KINGSIDE_RIGHTS,
+            'q' => BLACK_QUEENSIDE_RIGHTS,
+            _ => {
+                return Err(FenParseError::InvalidCastlingRights {
+                    invalid_castling: c,
+                })
+            }
+        };
+    }
+    board.lose_castle_rights(!rights);
+    Ok(())
+}
+
+/// Parses the en passant target square field
+fn parse_en_passant(board: &mut Board, en_passant: &str) -> FenResult<()> {
+    if en_passant == "-" {
+        return Ok(());
+    }
+
+    if en_passant.len() != 2 {
+        return Err(FenParseError::InvalidEnPassant {
+            component: "square".to_string(),
+            value: en_passant.to_string(),
+        });
+    }
+
+    let file = en_passant
+        .chars()
+        .nth(0)
+        .ok_or_else(|| FenParseError::InvalidEnPassant {
+            component: "file".to_string(),
+            value: en_passant.to_string(),
+        })?;
+    let rank = en_passant
+        .chars()
+        .nth(1)
+        .ok_or_else(|| FenParseError::InvalidEnPassant {
+            component: "rank".to_string(),
+            value: en_passant.to_string(),
+        })?;
+
+    if !file.is_ascii_lowercase()
+        || file < 'a'
+        || file > 'h'
+        || !rank.is_ascii_digit()
+        || rank < '1'
+        || rank > '8'
+    {
+        return Err(FenParseError::InvalidEnPassant {
+            component: "square".to_string(),
+            value: en_passant.to_string(),
+        });
+    }
+
+    let file = file as u8 - b'a';
+    let rank = rank as u8 - b'1';
+    board.push_en_passant_target(from_rank_file(rank, file));
+    Ok(())
+}
+
+/// Parses the halfmove clock field
+fn parse_halfmove_clock(board: &mut Board, halfmove_clock: &str) -> FenResult<()> {
+    let halfmove =
+        halfmove_clock
+            .parse::<u8>()
+            .map_err(|_| FenParseError::InvalidHalfmoveClock {
+                invalid_clock: halfmove_clock.to_string(),
+            })?;
+    board.push_halfmove_clock(halfmove);
+    Ok(())
+}
+
+/// Parses the fullmove number field
+fn parse_fullmove_number(board: &mut Board, fullmove_number: &str) -> FenResult<()> {
+    let fullmove =
+        fullmove_number
+            .parse::<u8>()
+            .map_err(|_| FenParseError::InvalidFullmoveNumber {
+                invalid_number: fullmove_number.to_string(),
+            })?;
+    board.set_fullmove_clock(fullmove);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::bitboard::bitboard::Bitboard;
+
+    #[test]
+    fn test_parse_starting_position() {
+        let board: Board = STARTING_POSITION_FEN.parse().unwrap();
+        assert_eq!(
+            board.current_position_hash(),
+            Board::default().current_position_hash()
+        );
+    }
+
+    #[test]
+    fn test_parse_complex_position() {
+        let fen = "r1bqk2r/ppp2ppp/2n2n2/2bpp3/4P3/2PP1N2/PP1N1PPP/R1BQKB1R b KQkq - 0 6";
+        let board = parse_fen(fen).unwrap();
+
+        // Verify some key aspects of the position
+        assert_eq!(board.turn(), Color::Black);
+        assert_eq!(board.halfmove_clock(), 0);
+        assert_eq!(board.fullmove_clock(), 6);
+
+        // Verify a few piece positions
+        assert_eq!(
+            board.get(from_rank_file(7, 0)),
+            Some((Piece::Rook, Color::Black))
+        );
+        assert_eq!(
+            board.get(from_rank_file(4, 4)),
+            Some((Piece::Pawn, Color::Black))
+        );
+    }
+
+    #[test]
+    fn test_invalid_fen() {
+        // Test invalid number of fields
+        assert!(parse_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -").is_err());
+
+        // Test invalid piece placement
+        assert!(parse_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBN w KQkq - 0 1").is_err());
+
+        // Test invalid active color
+        assert!(parse_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR x KQkq - 0 1").is_err());
+
+        // Test invalid castling rights
+        assert!(parse_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w XYZx - 0 1").is_err());
+    }
+
+    #[test]
+    fn test_empty_squares() {
+        let fen = "8/8/8/8/8/8/8/8 w - - 0 1";
+        let board = parse_fen(fen).unwrap();
+        assert_eq!(board.occupied(), Bitboard::EMPTY);
+    }
+
+    #[test]
+    fn test_en_passant_parsing() {
+        let fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+        let board = parse_fen(fen).unwrap();
+        assert_eq!(board.peek_en_passant_target(), from_rank_file(2, 4));
+    }
+
+    #[test]
+    fn test_castle_rights() {
+        // Test all castle rights
+        let fen = "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1";
+        let board = parse_fen(fen).unwrap();
+        assert_eq!(board.peek_castle_rights(), ALL_CASTLE_RIGHTS);
+
+        // Test no castle rights
+        let fen = "r3k2r/8/8/8/8/8/8/R3K2R w - - 0 1";
+        let board = parse_fen(fen).unwrap();
+        assert_eq!(board.peek_castle_rights(), 0);
+
+        // Test partial castle rights
+        let fen = "r3k2r/8/8/8/8/8/8/R3K2R w Kq - 0 1";
+        let board = parse_fen(fen).unwrap();
+        assert_eq!(
+            board.peek_castle_rights(),
+            WHITE_KINGSIDE_RIGHTS | BLACK_QUEENSIDE_RIGHTS
+        );
+    }
+}

--- a/src/input_handler/mod.rs
+++ b/src/input_handler/mod.rs
@@ -3,6 +3,8 @@ use std::io;
 use std::str::FromStr;
 use thiserror::Error;
 
+pub mod fen;
+
 #[derive(Error, Debug)]
 pub enum InputError {
     #[error("io error: {error:?}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use chess::board::color::Color;
+use chess::game::engine::EngineConfig;
 use chess::game::mode::{ComputerVsComputer, HumanVsComputer, HumanVsHuman};
 use chess::game::position_counter::{run_count_positions, CountPositionsStrategy};
 use chess::game::r#loop::GameLoop;
@@ -66,20 +67,26 @@ fn main() {
     match args {
         Chess::Play { depth, color } => {
             let mode = HumanVsComputer { human_color: color };
-            let mut game = GameLoop::new(mode, Some(depth));
+            let config = EngineConfig {
+                search_depth: depth,
+            };
+            let mut game = GameLoop::new(mode, config);
             game.run();
         }
         Chess::Watch { depth } => {
             let mode = ComputerVsComputer {
-                depth,
-                delay: Some(Duration::from_millis(1000)),
+                delay_between_moves: Some(Duration::from_millis(1000)),
             };
-            let mut game = GameLoop::new(mode, Some(depth));
+            let config = EngineConfig {
+                search_depth: depth,
+            };
+            let mut game = GameLoop::new(mode, config);
             game.run();
         }
         Chess::Pvp => {
             let mode = HumanVsHuman;
-            let mut game = GameLoop::new(mode, None);
+            let config = EngineConfig { search_depth: 0 };
+            let mut game = GameLoop::new(mode, config);
             game.run();
         }
         Chess::CountPositions { depth, strategy } => run_count_positions(depth, strategy),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,52 +1,65 @@
 use std::time::Duration;
 
 use chess::board::color::Color;
-use chess::game::engine::EngineConfig;
+use chess::board::Board;
+use chess::game::engine::{Engine, EngineConfig};
 use chess::game::mode::{ComputerVsComputer, HumanVsComputer, HumanVsHuman};
 use chess::game::position_counter::{run_count_positions, CountPositionsStrategy};
 use chess::game::r#loop::GameLoop;
 use chess::game::stockfish_elo::determine_stockfish_elo;
+use chess::input_handler::fen::STARTING_POSITION_FEN;
 use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt)]
 #[structopt(
     name = "chess",
     about = "A classical chess engine implemented in Rust ♛"
 )]
 enum Chess {
-    #[structopt(
-        name = "count-positions",
-        about = "Count the number of possible positions for a given `--depth` (default: 4), and reports the time it took to do so. By default, this searches all possible positions. The routine can be run with alpha-beta pruning by selecting `--strategy alpha-beta`."
-    )]
-    CountPositions {
-        #[structopt(short, long, default_value = "4")]
-        depth: u8,
-        #[structopt(short, long, default_value = "all")]
-        strategy: CountPositionsStrategy,
-    },
+    // Gameplay commands
     #[structopt(
         name = "play",
-        about = "Play a game against the computer, which will search for the best move using alpha-beta pruning at the given `--depth` (default: 4). Your starting color will be chosen at random unless you specify with `--color`."
+        about = "Play a game against the computer, which will search for the best move using alpha-beta pruning at the given `--depth` (default: 4). Your starting color will be chosen at random unless you specify with `--color`. The initial position can be specified using FEN notation with `--fen` (default: starting position)."
     )]
     Play {
         #[structopt(short, long, default_value = "4")]
         depth: u8,
         #[structopt(short = "c", long = "color", default_value = "random")]
         color: Color,
+        #[structopt(long = "fen", default_value = STARTING_POSITION_FEN)]
+        starting_position: Board,
     },
     #[structopt(
         name = "pvp",
-        about = "Play a game against another human on this local machine."
+        about = "Play a game against another human on this local machine. The initial position can be specified using FEN notation with `--fen` (default: starting position)."
     )]
-    Pvp,
+    Pvp {
+        #[structopt(long = "fen", default_value = STARTING_POSITION_FEN)]
+        starting_position: Board,
+    },
     #[structopt(
         name = "watch",
-        about = "Watch the computer play against itself at the given `--depth` (default: 4)."
+        about = "Watch the computer play against itself at the given `--depth` (default: 4). The initial position can be specified using FEN notation with `--fen` (default: starting position)."
     )]
     Watch {
         #[structopt(short, long, default_value = "4")]
         depth: u8,
+        #[structopt(long = "fen", default_value = STARTING_POSITION_FEN)]
+        starting_position: Board,
     },
+
+    // Utility commands
+    #[structopt(
+        name = "calculate-best-move",
+        about = "Use the chess engine to determine the best move from a given position, provided in FEN notation with `--fen` (required). You can optionally specify the depth of the search with the `--depth` arg (default: 4)."
+    )]
+    CalculateBestMove {
+        #[structopt(short, long, default_value = "4")]
+        depth: u8,
+        #[structopt(long = "fen")]
+        starting_position: Board,
+    },
+
     #[structopt(
         name = "determine-stockfish-elo",
         about = "Determine the ELO rating of the engine at a given `--depth` (default: 4) and `--starting-elo` (default: 1000). The engine will increment the Stockfish ELO until it plateaus at a 50% win rate, at which point the rating is reported."
@@ -57,6 +70,16 @@ enum Chess {
         #[structopt(short, long, default_value = "1000")]
         starting_elo: u32,
     },
+    #[structopt(
+        name = "count-positions",
+        about = "Count the number of possible positions for a given `--depth` (default: 4), and reports the time it took to do so. By default, this searches all possible positions. The routine can be run with alpha-beta pruning by selecting `--strategy alpha-beta`."
+    )]
+    CountPositions {
+        #[structopt(short, long, default_value = "4")]
+        depth: u8,
+        #[structopt(short, long, default_value = "all")]
+        strategy: CountPositionsStrategy,
+    },
 }
 
 fn main() {
@@ -65,34 +88,74 @@ fn main() {
     let args = Chess::from_args();
 
     match args {
-        Chess::Play { depth, color } => {
+        Chess::Play {
+            depth,
+            color,
+            starting_position,
+        } => {
             let mode = HumanVsComputer { human_color: color };
             let config = EngineConfig {
                 search_depth: depth,
+                starting_position,
             };
             let mut game = GameLoop::new(mode, config);
             game.run();
         }
-        Chess::Watch { depth } => {
+        Chess::Watch {
+            depth,
+            starting_position,
+        } => {
             let mode = ComputerVsComputer {
                 delay_between_moves: Some(Duration::from_millis(1000)),
             };
             let config = EngineConfig {
                 search_depth: depth,
+                starting_position,
             };
             let mut game = GameLoop::new(mode, config);
             game.run();
         }
-        Chess::Pvp => {
+        Chess::Pvp { starting_position } => {
             let mode = HumanVsHuman;
-            let config = EngineConfig { search_depth: 0 };
+            let config = EngineConfig {
+                search_depth: 0,
+                starting_position,
+            };
             let mut game = GameLoop::new(mode, config);
             game.run();
         }
-        Chess::CountPositions { depth, strategy } => run_count_positions(depth, strategy),
+        Chess::CalculateBestMove {
+            depth,
+            starting_position,
+        } => {
+            let config = EngineConfig {
+                search_depth: depth,
+                starting_position,
+            };
+            let mut engine = Engine::with_config(config);
+            let valid_moves = engine.get_valid_moves();
+            if valid_moves.len() == 0 {
+                eprintln!("There are no valid moves in the given position.");
+                return;
+            }
+            match engine.get_best_move() {
+                Ok(best_move) => {
+                    let algebraic_move = valid_moves
+                        .iter()
+                        .find(|(chess_move, _)| chess_move == &best_move)
+                        .map(|(_, algebraic_notation)| algebraic_notation.as_str())
+                        .unwrap();
+                    println!("{}", algebraic_move);
+                }
+                Err(err) => {
+                    eprintln!("Failed to calculate best move: {}", err);
+                }
+            }
+        }
         Chess::DetermineStockfishElo {
             depth,
             starting_elo,
         } => determine_stockfish_elo(depth, starting_elo),
+        Chess::CountPositions { depth, strategy } => run_count_positions(depth, strategy),
     }
 }

--- a/src/move_generator/targets.rs
+++ b/src/move_generator/targets.rs
@@ -354,7 +354,7 @@ mod tests {
     #[test]
     pub fn test_generate_attack_targets_2() {
         let mut targets = Targets::new();
-        let mut board = Board::starting_position();
+        let mut board = Board::default();
         let moves = [
             std_move!(E2, E4),
             std_move!(F7, F5),


### PR DESCRIPTION
Resolves #1.

* Adds CLI support for passing in a `--fen` for any of the gameplay commands
* Introduces a `calculate-best-move` command that returns the best move from the given position (`--fen`) and `--depth` (default 4).

Example:

```console
$ chess calculate-best-move --fen "1Q6/8/8/8/8/k1K5/8/8 w - - 0 1"
Qb3#
```

Here are the complete CLI docs, for posterity:

```console
$ chess --help

chess 1.0.0
A classical chess engine implemented in Rust ♛

USAGE:
    chess <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    calculate-best-move        Use the chess engine to determine the best move from a given position, provided in
                               FEN notation with `--fen` (required). You can optionally specify the depth of the
                               search with the `--depth` arg (default: 4).
    count-positions            Count the number of possible positions for a given `--depth` (default: 4), and
                               reports the time it took to do so. By default, this searches all possible positions.
                               The routine can be run with alpha-beta pruning by selecting `--strategy alpha-beta`.
    determine-stockfish-elo    Determine the ELO rating of the engine at a given `--depth` (default: 4) and
                               `--starting-elo` (default: 1000). The engine will increment the Stockfish ELO until
                               it plateaus at a 50% win rate, at which point the rating is reported.
    help                       Prints this message or the help of the given subcommand(s)
    play                       Play a game against the computer, which will search for the best move using alpha-
                               beta pruning at the given `--depth` (default: 4). Your starting color will be
                               chosen at random unless you specify with `--color`. The initial position can be
                               specified using FEN notation with `--fen` (default: starting position).
    pvp                        Play a game against another human on this local machine. The initial position can be
                               specified using FEN notation with `--fen` (default: starting position).
    watch                      Watch the computer play against itself at the given `--depth` (default: 4). The
                               initial position can be specified using FEN notation with `--fen` (default: starting
                               position).
```